### PR TITLE
ubuild test: honoring different build.root

### DIFF
--- a/orbital_core/build/tasks.py
+++ b/orbital_core/build/tasks.py
@@ -16,7 +16,7 @@ def test(build):
     build.packages.install("pytest-runfailed")
     build.executables.run([
         "py.test", "--cov", build.config["module"],
-        "{0}/tests".format(build.config["module"]),
+        os.path.join(build.root, build.config["module"], "tests"),
         "--cov-report", "term-missing",
         "-n", "{0}".format(multiprocessing.cpu_count())
     ] + build.options.args)


### PR DESCRIPTION
uranium 2.0 now runs everything inside of a virtualenv in the .virtualenv directory. In this
world, every invocation of build.executables needs to specify the directory
where source files are located in. test did not specify a root directory, so it was looking
in the virtualenv vs the source directory.